### PR TITLE
Fix compatibility with contao 4.13

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -5,6 +5,8 @@ services:
             - '@doctrine.orm.entity_manager'
             - '@contao_push.repository.push'
             - '@monolog.logger.contao'
+        calls:
+            - [setContainer, ['@service_container']]
 
     contao_push.controller.module_push_notification_button:
         class: Dreibein\ContaoPushBundle\Controller\FrontendModule\PushNotificationButton

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -26,6 +26,8 @@ services:
 
     contao_push.listener.symlink.service_worker:
         class: Dreibein\ContaoPushBundle\EventListener\ServiceWorkerSymlinkListener
+        arguments:
+            - '@parameter_bag'
         tags:
             - { name: kernel.event_listener, event: contao.generate_symlinks, method: onGenerateSymlinks, priority: 128 }
 

--- a/src/EventListener/ServiceWorkerSymlinkListener.php
+++ b/src/EventListener/ServiceWorkerSymlinkListener.php
@@ -10,14 +10,26 @@ declare(strict_types=1);
 namespace Dreibein\ContaoPushBundle\EventListener;
 
 use Contao\CoreBundle\Event\GenerateSymlinksEvent;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 
 final class ServiceWorkerSymlinkListener
 {
+    /**
+     * @var ParameterBagInterface
+     */
+    private $bag;
+
+    public function __construct(ParameterBagInterface $bag)
+    {
+        $this->bag = $bag;
+    }
+
     /**
      * @param GenerateSymlinksEvent $event
      */
     public function onGenerateSymlinks(GenerateSymlinksEvent $event): void
     {
-        $event->addSymlink('web/bundles/contaopush/sw.js', 'web/contao-push-sw.js');
+        $webDir = $this->bag->get('contao.web_dir');
+        $event->addSymlink($webDir . '/bundles/contaopush/sw.js', $webDir . '/contao-push-sw.js');
     }
 }


### PR DESCRIPTION
This PR fixes the compatibility  with contao 4.13
- service container call #2
- symlink in contao web dir - can be `public` instead of `web`